### PR TITLE
Turn off codecov comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 10% drop from the previous base commit coverage
+        threshold: 10%


### PR DESCRIPTION
Turn off codecov comments and add threshhold, not sure if this has any impact if bors doesn't depend on the codecov status, though.